### PR TITLE
Added Redis Sentinel Support

### DIFF
--- a/celery_singleton/backends/__init__.py
+++ b/celery_singleton/backends/__init__.py
@@ -19,7 +19,8 @@ def get_backend(config):
     klass = config.backend_class
     kwargs = config.backend_kwargs
     url = config.backend_url
-    _backend = klass(url, **kwargs)
+    broker_transport_options = config.broker_transport_options
+    _backend = klass(url, broker_transport_options=broker_transport_options, **kwargs)
     return _backend
 
 

--- a/celery_singleton/backends/redis.py
+++ b/celery_singleton/backends/redis.py
@@ -1,6 +1,27 @@
 from redis import Redis
+from redis.sentinel import Sentinel
+
+import re
 
 from .base import BaseBackend
+
+
+class ParseSentinelURL(object):
+    def __init__(self, sentinel_url):
+        self.sentinel_url = sentinel_url
+        self.default_port = 26379
+
+    def parse(self):
+        sentinel_config = list()
+
+        for url in self.sentinel_url.split(";"):
+            host = re.search(r"(?<=@)(.+?)(?=:|;|$)", url)
+            host = host.group() if host else None
+
+            port = re.search(r"(?<=:)(\d+)(?=;|$)", url)
+            port = int(port.group()) if port else self.default_port
+            sentinel_config.append((host, port))
+        return sentinel_config
 
 
 class RedisBackend(BaseBackend):
@@ -8,7 +29,21 @@ class RedisBackend(BaseBackend):
         """
         args and kwargs are forwarded to redis.from_url
         """
-        self.redis = Redis.from_url(*args, decode_responses=True, **kwargs)
+
+        if args[0].startswith(r"sentinel://"):
+            sentinel_config = ParseSentinelURL(sentinel_url=args[0]).parse()
+            broker_transport_options = kwargs['broker_transport_options']
+            sentinel_kwargs = broker_transport_options.get('sentinel_kwargs')
+            sentinel_password = sentinel_kwargs.get('password') if isinstance(sentinel_kwargs, dict) else None
+
+            sentinel = Sentinel(sentinel_config,
+                                sentinel_kwargs=sentinel_kwargs,
+                                password=sentinel_password)
+            
+            self.redis = sentinel.master_for(broker_transport_options['master_name'])
+
+        else:
+            self.redis = Redis.from_url(*args, decode_responses=True, **kwargs)
 
     def lock(self, lock, task_id, expiry=None):
         return not not self.redis.set(lock, task_id, nx=True, ex=expiry)

--- a/celery_singleton/config.py
+++ b/celery_singleton/config.py
@@ -36,6 +36,10 @@ class Config:
         return url
 
     @property
+    def broker_transport_options(self):
+        return self.app.conf.get('broker_transport_options')
+
+    @property
     def raise_on_duplicate(self):
         return self.app.conf.get("singleton_raise_on_duplicate")
 


### PR DESCRIPTION
Support for Redis Sentinel configuration as follows:

`app.conf.broker_url = 'sentinel://:password@localhost:26379;sentinel://:password@localhost:26380;sentinel://:password@localhost:26381'
app.conf.broker_transport_options = { 'master_name': "cluster1", sentinel_kwargs': {'password': 'password'} }`

#34 