### PR TITLE
unique_on improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ task2 = do_something.delay(username='bob', otherarg=100)  # this is a duplicate 
 assert task1 == task2
 ```
 
+Specify an empty list to consider the task name only.
+
 ### raise\_on\_duplicate
 
 When this option is enabled the task's `delay` and `apply_async` method will raise a `DuplicateTaskError` exception when attempting to spawn a duplicate task instead of returning the existing task's `AsyncResult`

--- a/celery_singleton/singleton.py
+++ b/celery_singleton/singleton.py
@@ -57,14 +57,16 @@ class Singleton(BaseTask):
         unique_on = self.unique_on
         task_args = task_args or []
         task_kwargs = task_kwargs or {}
-        if unique_on:
+        if unique_on is not None:
             if isinstance(unique_on, str):
                 unique_on = [unique_on]
-            sig = inspect.signature(self.run)
-            bound = sig.bind(*task_args, **task_kwargs).arguments
-
+            if not any(unique_on):
+                unique_kwargs = {}
+            else:
+                sig = inspect.signature(self.run)
+                bound = sig.bind(*task_args, **task_kwargs).arguments
+                unique_kwargs = {key: bound[key] for key in unique_on}
             unique_args = []
-            unique_kwargs = {key: bound[key] for key in unique_on}
         else:
             unique_args = task_args
             unique_kwargs = task_kwargs

--- a/celery_singleton/singleton.py
+++ b/celery_singleton/singleton.py
@@ -64,8 +64,9 @@ class Singleton(BaseTask):
                 unique_kwargs = {}
             else:
                 sig = inspect.signature(self.run)
-                bound = sig.bind(*task_args, **task_kwargs).arguments
-                unique_kwargs = {key: bound[key] for key in unique_on}
+                bound = sig.bind(*task_args, **task_kwargs)
+                bound.apply_defaults()
+                unique_kwargs = {key: bound.arguments[key] for key in unique_on}
             unique_args = []
         else:
             unique_args = task_args


### PR DESCRIPTION
Makes two changes to `unique_on` behavior.

1. Allows specifying `unique_on=[]` to consider task name only for uniqueness:
    
    ```python
    @app.task(base=Singleton, unique_on=[])
    def do_something(username, otherarg=None):
        time.sleep(5)

    # Previous behavior: equivalent to unique_on=None ([] parsed as falsey value)
    # New behavior: only the task name "do_something" is used to generate lock
    ```

2. Allows tasks with default arguments in `unique_on` to be called without explicitly specifying values:

    ```python
    @app.task(base=Singleton, unique_on=["otherarg"])
    def do_something(username, otherarg=None):
        time.sleep(5)
    otherarg.delay(sample)

    # Previous behavior: exception raised in generate_lock due to missing key in BoundArguments
    # New behavior: default arguments can be omitted when calling task
    ```

Resolves #15 
Resolves #23 