### PR TITLE
Optional setting `single_json_encoder_class`: Set `json`-compatible encoder class to `generate_lock()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### Added
+- Support passing an optional custom [`json.JSONEncoder`] to `util.generate_lock()` via `singleton_json_encoder_class`.
+  Useful for task arguments with objects marshalable to the same string representation, e.g. passing [`uuid.UUID`] to  [`str()`].
+
+  PR [#44](https://github.com/steinitzu/celery-singleton/pull/44) by [Tony Narlock](https://github.com/tony) in regards to [#42](https://github.com/steinitzu/celery-singleton/issues/42) and [#36](https://github.com/steinitzu/celery-singleton/issues/36).
+
+[`json.JSONEncoder`]: https://docs.python.org/3/library/json.html#json.JSONEncoder
+[`str()`]: https://docs.python.org/3/library/stdtypes.html#str
+[`uuid.UUID`]: https://docs.python.org/3/library/uuid.html#uuid.UUID
+
 ## [0.3.1] - 2021-01-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -196,11 +196,14 @@ Note: if using old style celery config with uppercase variables and a namespace,
 | `singleton_backend_url`        | `celery_backend_url`                    | The URL of the storage backend. If using the default backend implementation, this should be a redis URL. It is passed as the first argument to the backend class.    |
 | `singleton_backend_class`      | `celery_singleton.backend.RedisBackend` | The full import path of a backend class as string or a reference to the class                                                                                       |
 | `singleton_backend_kwargs`     | `{}`                                    | Passed as keyword arguments to the backend class                                                                                                                     |
+| `singleton_json_encoder_class` | `None` ([`json.JSONEncoder`]) | Optional JSON encoder class for generating lock. Useful for task arguments where objects can be reliably marshalled to string (such as [`uuid.UUID`])                                                                                              |
 | `singleton_key_prefix`         | `SINGLETONLOCK_`                        | Locks are stored as `<key_prefix><lock>`. Use to prevent collisions with other keys in your database.                                                                |
 | `singleton_raise_on_duplicate` | `False`                                 | When `True` an attempt to queue a duplicate task will raise a `DuplicateTaskerror`. The default behavior is to return the `AsyncResult` for the existing task.       |
 | `singleton_lock_expiry`        | `None` (Never expires)                  | Lock expiry time in second for singleton task locks. When lock expires identical tasks are allowed to run regardless of whether the locked task has finished or not. |
 |                                |                                         |                                                                                                                                                                      |
 
+[`json.JSONEncoder`]: https://docs.python.org/3/library/json.html#json.JSONEncoder
+[`uuid.UUID`]: https://docs.python.org/3/library/uuid.html#uuid.UUID
 
 ## Testing
 

--- a/celery_singleton/config.py
+++ b/celery_singleton/config.py
@@ -22,6 +22,16 @@ class Config:
         return path_or_class
 
     @property
+    def json_encoder_class(self):
+        path_or_class = self.app.conf.get("singleton_json_encoder_class", None)
+        if isinstance(path_or_class, str):
+            path = path_or_class.split(".")
+            mod_name, class_name = ".".join(path[:-1]), path[-1]
+            mod = import_module(mod_name)
+            return getattr(mod, class_name)
+        return path_or_class
+
+    @property
     def backend_kwargs(self):
         return self.app.conf.get("singleton_backend_kwargs", {})
 

--- a/celery_singleton/singleton.py
+++ b/celery_singleton/singleton.py
@@ -76,6 +76,7 @@ class Singleton(BaseTask):
             unique_args,
             unique_kwargs,
             key_prefix=self.singleton_config.key_prefix,
+            json_encoder_class=self.singleton_config.json_encoder_class,
         )
 
     def apply_async(

--- a/celery_singleton/util.py
+++ b/celery_singleton/util.py
@@ -3,10 +3,14 @@ from hashlib import md5
 
 
 def generate_lock(
-    task_name, task_args=None, task_kwargs=None, key_prefix="SINGLETONLOCK_"
+    task_name,
+    task_args=None,
+    task_kwargs=None,
+    key_prefix="SINGLETONLOCK_",
+    json_encoder_class=None,
 ):
-    str_args = json.dumps(task_args or [], sort_keys=True)
-    str_kwargs = json.dumps(task_kwargs or {}, sort_keys=True)
+    str_args = json.dumps(task_args or [], sort_keys=True, cls=json_encoder_class)
+    str_kwargs = json.dumps(task_kwargs or {}, sort_keys=True, cls=json_encoder_class)
     task_hash = md5((task_name + str_args + str_kwargs).encode()).hexdigest()
     key_prefix = key_prefix
     return key_prefix + task_hash


### PR DESCRIPTION
Fixes cases such as #42 #36 

[`json.dumps()`](https://docs.python.org/3/library/json.html#json.dumps) accepts an optional `cls` of a [`jsonJSONEncoder`](https://docs.python.org/3/library/json.html#json.JSONEncoder)

This matches the intention of the `json` library.

This is great for cases where users use a celery backend that supports passing `uuid.UUID` arguments and simply needs to cast. Many codebases already have an encoder for such purposes, some major packages have them such as [`django.core.serializers.json.DjangoJSONEncoder`](https://github.com/django/django/blob/4.0.2/django/core/serializers/json.py#L77-L105)