### PR TITLE
Don't unlock the task if lock_expiry is still valid

### DIFF
--- a/celery_singleton/singleton.py
+++ b/celery_singleton/singleton.py
@@ -150,4 +150,5 @@ class Singleton(BaseTask):
         self.release_lock(task_args=args, task_kwargs=kwargs)
 
     def on_success(self, retval, task_id, args, kwargs):
-        self.release_lock(task_args=args, task_kwargs=kwargs)
+        if self.lock_expiry is None:
+            self.release_lock(task_args=args, task_kwargs=kwargs)


### PR DESCRIPTION
Hi! 

In my use case I need the task result to be cached until the lock time expires, in order to avoid new tasks with the same input data.
Does it make sense to you keeping the lock even if the task has finished?