### PR TITLE
chore(poetry): use poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,5 @@ pytest-cov = "*"
 pytest-celery = "*"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Before 1.1.0, it made sense to use poetry as a PEP517 build backend but now that
https://pypi.org/project/poetry-core/ exist, it's a lightweight alternative that does not require
installing Poetry for this.
